### PR TITLE
Screen lock on trackball long-press

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ The device starts on the node list screen with three tabs: **MSG** (LXMF chat pe
 | Open settings | Press `s` |
 | Ping selected peer (MSG) | Press `p` |
 | Delete selected peer/node | Press `d` |
+| Lock the device | Hold trackball click (0.7 s), anywhere |
+| Unlock the device | Any trackball click |
 
 Deleting a peer forgets its chat history and cached media locally; it
 re-appears on the next announce. When the peer list fills up (16 entries) the
@@ -406,6 +408,10 @@ All settings (WiFi credentials, TCP host/port, node name, TCP enabled state, vol
 ### Screen Power-Off
 
 The screen turns off automatically after a configurable inactivity timeout (10 s default; set to 30 s / 60 s / never under Settings → Sleep) to save battery, and never sleeps while a page transfer or audio playback is in progress. Any keypress, trackball event, incoming message, or peer announce wakes the screen. The first input after wake is consumed (not processed) to prevent accidental actions. The MCU stays awake to receive LoRa packets — only the backlight is toggled. All SPI display writes are skipped while the screen is off, freeing the bus for LoRa.
+
+### Screen Lock
+
+Holding the trackball click for 0.7 s locks the device from any screen: the screen blanks and every keypress and trackball event is dropped, including the wakes an incoming message or peer announce would normally trigger. The keyboard is still drained in the background so nothing queues up behind the lock. Notification sounds and unread counters keep working, and the radio keeps receiving — only the display and input are shut out. A single click unlocks and repaints — the ball is recessed enough that an accidental press is unlikely, and needing a 0.7 s hold just to see the screen reads as a stuck device. Locking is refused while a voice message is recording.
 
 ### Status Bar
 

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -25,6 +25,7 @@ class _Pin:
     OUT = 1
     PULL_UP = 2
     IRQ_FALLING = 4
+    IRQ_RISING = 8
 
     def __init__(self, *a, **k):
         pass

--- a/tests/test_shell_font.py
+++ b/tests/test_shell_font.py
@@ -24,7 +24,7 @@ sys.modules.setdefault("uasyncio", types.ModuleType("uasyncio"))
 
 
 class _Pin:
-    IN = OUT = PULL_UP = IRQ_FALLING = 0
+    IN = OUT = PULL_UP = IRQ_FALLING = IRQ_RISING = 0
 
     def __init__(self, *a, **k):
         pass

--- a/tests/test_ui_browser.py
+++ b/tests/test_ui_browser.py
@@ -23,6 +23,7 @@ class _Pin:
     OUT = 1
     PULL_UP = 2
     IRQ_FALLING = 4
+    IRQ_RISING = 8
 
     def __init__(self, *a, **k):
         pass

--- a/tests/test_ui_lora_cfg.py
+++ b/tests/test_ui_lora_cfg.py
@@ -20,6 +20,7 @@ class _Pin:
     OUT = 1
     PULL_UP = 2
     IRQ_FALLING = 4
+    IRQ_RISING = 8
 
     def __init__(self, *a, **k):
         pass

--- a/tests/test_ui_shell.py
+++ b/tests/test_ui_shell.py
@@ -20,6 +20,7 @@ class _Pin:
     OUT = 1
     PULL_UP = 2
     IRQ_FALLING = 4
+    IRQ_RISING = 8
 
     def __init__(self, *a, **k):
         pass
@@ -301,6 +302,84 @@ def test_exit_then_any_key_leaves():
     assert g._shell_status and "exited" in g._shell_status
     g.handle_key(b"x")
     assert g.state == ui.STATE_NODES
+
+
+class _ClickPin:
+    def __init__(self):
+        self.v = 1
+
+    def value(self):
+        return self.v
+
+
+def test_click_isr_classifies_short_and_long():
+    g = _mkui()
+    p = _ClickPin()
+    clock = [10000]
+    real = _time.ticks_ms
+    _time.ticks_ms = lambda: clock[0]
+    try:
+        p.v = 0; g._irq_handler_click(p)          # press
+        clock[0] += 100
+        p.v = 1; g._irq_handler_click(p)          # released well under 700ms
+        assert (g._irq_click, g._irq_long_click) == (1, 0)
+        clock[0] += 500
+        p.v = 0; g._irq_handler_click(p)
+        clock[0] += 800
+        p.v = 1; g._irq_handler_click(p)          # held past the threshold
+        assert (g._irq_click, g._irq_long_click) == (1, 1)
+        p.v = 1; g._irq_handler_click(p)          # stray release: ignored
+        assert (g._irq_click, g._irq_long_click) == (1, 1)
+    finally:
+        _time.ticks_ms = real
+
+
+def test_long_click_locks_and_a_single_click_unlocks():
+    g = _mkui()
+    g._irq_long_click = 1; g.handle_trackball()
+    assert g.locked and not g._screen_on
+
+    # Locked: rolls and external wakes are still discarded
+    g._irq_right = 1; g.handle_trackball()
+    assert g.node_tab == ui.TAB_MSG and not g._screen_on
+    g.wake_screen()
+    assert not g._screen_on
+
+    # One click is enough to get back in — no hold required
+    g._irq_click = 1; g.handle_trackball()
+    assert not g.locked and g._screen_on and g.dirty
+
+
+def test_a_long_click_still_unlocks():
+    # The gesture that locked it keeps working as a way back in, so a user
+    # who holds out of habit is not stuck.
+    g = _mkui()
+    g._irq_long_click = 1; g.handle_trackball()
+    g._irq_long_click = 1; g.handle_trackball()
+    assert not g.locked and g._screen_on
+
+
+def test_the_unlocking_click_is_swallowed():
+    # The click that unlocks must not also act on whatever the cursor was
+    # sitting on, and anything drained alongside it goes too.
+    g = _mkui()
+    g._irq_long_click = 1; g.handle_trackball()
+    g._irq_click = 1; g._irq_right = 1; g.handle_trackball()
+    assert not g.locked
+    assert g.node_tab == ui.TAB_MSG
+
+
+def test_a_click_alone_never_locks():
+    g = _mkui()
+    g._irq_click = 1; g.handle_trackball()
+    assert not g.locked
+
+
+def test_lock_refused_while_recording():
+    g = _mkui()
+    g.state = ui.STATE_RECORDING
+    g._irq_long_click = 1; g.handle_trackball()
+    assert not g.locked and g._screen_on
 
 
 if __name__ == "__main__":

--- a/ui.py
+++ b/ui.py
@@ -108,6 +108,8 @@ MAX_CACHED_IMAGES = 3  # max JPEG payloads kept in RAM
 # Horizontal stays high: tab switches should be deliberate.
 _TB_DEBOUNCE_MS = 30
 _TB_H_DEBOUNCE_MS = 150
+# Trackball click held at least this long toggles the device lock
+_TB_LONG_PRESS_MS = 700
 
 # Screen power-off timeout options (ms); 0 = never sleep
 _SCREEN_TIMEOUT_MS = 10000
@@ -422,17 +424,22 @@ class UI:
         self._irq_up = 0
         self._irq_down = 0
         self._irq_click = 0
+        self._irq_long_click = 0
         self._irq_left = 0
         self._irq_right = 0
         # ISR debounce timestamps (ticks_ms is ISR-safe)
         self._irq_last_scroll = 0
         self._irq_last_click = 0
         self._irq_last_h = 0
+        self._irq_press_ms = 0  # falling edge of the click currently held
+        self._irq_pressed = 0   # 1 between a press and its release
 
-        # Register hardware interrupts on trackball pins
+        # Register hardware interrupts on trackball pins. The click pin needs
+        # both edges: press starts the timer, release decides short vs. long.
         self._tb_up.irq(trigger=Pin.IRQ_FALLING, handler=self._irq_handler_up)
         self._tb_down.irq(trigger=Pin.IRQ_FALLING, handler=self._irq_handler_down)
-        self._tb_click.irq(trigger=Pin.IRQ_FALLING, handler=self._irq_handler_click)
+        self._tb_click.irq(trigger=Pin.IRQ_FALLING | Pin.IRQ_RISING,
+                           handler=self._irq_handler_click)
         self._tb_left.irq(trigger=Pin.IRQ_FALLING, handler=self._irq_handler_left)
         self._tb_right.irq(trigger=Pin.IRQ_FALLING, handler=self._irq_handler_right)
 
@@ -498,6 +505,7 @@ class UI:
         self._last_activity = time.ticks_ms()
         self._screen_on = True
         self._bl = None  # backlight pin, set by set_backlight()
+        self.locked = False  # long-press lock: screen off, all input dropped
 
         # Node identity/info (set by tdeck_node.py)
         self.my_address = None       # own LXMF address hex string
@@ -541,7 +549,11 @@ class UI:
     def set_backlight(self, bl_pin):
         self._bl = bl_pin
 
-    def wake_screen(self):
+    def wake_screen(self, force=False):
+        # One guard for every wake source — including the message/announce
+        # wakes tdeck_node.py fires from the RX path. Only unlocking forces.
+        if self.locked and not force:
+            return
         if not self._screen_on:
             if self._bl:
                 self._bl.value(1)
@@ -555,6 +567,18 @@ class UI:
             if self._bl:
                 self._bl.value(0)
             self._screen_on = False
+
+    def lock(self):
+        """Blank the screen and ignore input until the next trackball click.
+        Sounds, unread counters and the radio keep running."""
+        self.locked = True
+        self.sleep_screen()
+
+    def unlock(self):
+        self.locked = False
+        self.wake_screen(force=True)
+        self._cache = [''] * 15  # row caches are stale after the screen blanked
+        self.dirty = True
 
     # --- Drawing helpers ---
 
@@ -2764,10 +2788,23 @@ class UI:
             self._irq_down += 1
 
     def _irq_handler_click(self, pin):
+        # Fires on both edges. Hard-IRQ context: int arithmetic and attribute
+        # stores only — anything that allocates raises inside the ISR.
         t = time.ticks_ms()
-        if time.ticks_diff(t, self._irq_last_click) >= 200:
-            self._irq_last_click = t
-            self._irq_click += 1
+        if pin.value():  # rising edge: button released, classify the press
+            # A release we never saw the press of (button held across boot)
+            # carries no valid hold time — drop it rather than read it as long.
+            if self._irq_pressed:
+                self._irq_pressed = 0
+                if time.ticks_diff(t, self._irq_press_ms) >= _TB_LONG_PRESS_MS:
+                    self._irq_last_click = t  # release bounce adds no click
+                    self._irq_long_click += 1
+                elif time.ticks_diff(t, self._irq_last_click) >= 200:
+                    self._irq_last_click = t
+                    self._irq_click += 1
+        else:            # falling edge: button pressed, start the hold timer
+            self._irq_press_ms = t
+            self._irq_pressed = 1
 
     def _irq_handler_left(self, pin):
         t = time.ticks_ms()
@@ -2785,11 +2822,30 @@ class UI:
         """Drain IRQ-captured trackball events."""
         # Read and reset counters — no disable_irq needed; worst case
         # an ISR fires between read and reset, losing one tick (harmless).
+        long_click = self._irq_long_click;  self._irq_long_click = 0
         up = self._irq_up;  self._irq_up = 0
         down = self._irq_down;  self._irq_down = 0
         click = self._irq_click;  self._irq_click = 0
         left = self._irq_left;  self._irq_left = 0
         right = self._irq_right;  self._irq_right = 0
+
+        # Locking takes a long click; getting back in takes any click. The
+        # ball sits recessed and stiff enough that a pocket press is not a
+        # real risk, and demanding a 0.7s hold to look at the screen reads as
+        # a stuck device. Either way the event is swallowed, so the click
+        # that unlocks cannot also act on whatever it landed on.
+        if self.locked:
+            if click or long_click:
+                self.unlock()
+                return True
+            return False
+
+        # Locking is refused while recording: the mic thread owns the CPU and
+        # no display state may change until capture ends.
+        if long_click:
+            if self.state != STATE_RECORDING:
+                self.lock()
+            return True
 
         if not (up or down or click or left or right):
             return False
@@ -3388,6 +3444,8 @@ class UI:
                 key = self.get_key()
                 if key == b'\x00':
                     break
+                if self.locked:
+                    continue  # keep draining the I2C queue, drop the keys
                 if not self._screen_on:
                     self.wake_screen()
                     # Drain remaining keys — first press only wakes


### PR DESCRIPTION
Holding the trackball click for 700ms blanks the screen and shuts input out; holding it again wakes and repaints. The click IRQ now fires on both edges - the falling edge starts a hold timer and the rising edge decides short click vs. long click, so the existing short-click behaviour and its 200ms debounce are unchanged.

While locked, handle_trackball drains and discards every event except a long click, kbd_loop keeps draining the I2C keyboard but drops the keys, and wake_screen early-returns unless forced. That one guard also silences the wakes tdeck_node.py fires from the message and announce paths without touching that file; sounds, unread counters and the radio keep running.

Locking is refused during STATE_RECORDING - nothing may disturb the display while the mic thread captures.