### PR TITLE
Wake policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ The device starts on the node list screen with three tabs: **MSG** (LXMF chat pe
 | Open settings | Press `s` |
 | Ping selected peer (MSG) | Press `p` |
 | Delete selected peer/node | Press `d` |
+| Lock the device | Hold trackball click (0.7 s), anywhere |
+| Unlock the device | Any trackball click |
 
 Deleting a peer forgets its chat history and cached media locally; it
 re-appears on the next announce. When the peer list fills up (16 entries) the
@@ -406,6 +408,10 @@ All settings (WiFi credentials, TCP host/port, node name, TCP enabled state, vol
 ### Screen Power-Off
 
 The screen turns off automatically after a configurable inactivity timeout (10 s default; set to 30 s / 60 s / never under Settings → Sleep) to save battery, and never sleeps while a page transfer or audio playback is in progress. Any keypress, trackball event, incoming message, or peer announce wakes the screen. The first input after wake is consumed (not processed) to prevent accidental actions. The MCU stays awake to receive LoRa packets — only the backlight is toggled. All SPI display writes are skipped while the screen is off, freeing the bus for LoRa.
+
+### Screen Lock
+
+Holding the trackball click for 0.7 s locks the device from any screen: the screen blanks and every keypress and trackball event is dropped, including the wakes an incoming message or peer announce would normally trigger. The keyboard is still drained in the background so nothing queues up behind the lock. Notification sounds and unread counters keep working, and the radio keeps receiving — only the display and input are shut out. A single click unlocks and repaints — the ball is recessed enough that an accidental press is unlikely, and needing a 0.7 s hold just to see the screen reads as a stuck device. Locking is refused while a voice message is recording.
 
 ### Status Bar
 

--- a/README.md
+++ b/README.md
@@ -401,13 +401,15 @@ Press `s` from the node list to open settings. Navigate with trackball, select w
 
 **Sleep** — Cycle the screen inactivity timeout (10 s / 30 s / 60 s / never). The screen never sleeps mid-transfer or mid-audio.
 
+**Wake** — What wakes the screen automatically: `msgs` (incoming messages only, the default), `all` (messages and peer announces — the pre-1.4 behaviour, keeps the screen lit on a busy mesh), or `never` (input only).
+
 Connecting to WiFi or a TCP server no longer freezes the UI — the screen shows `Connecting...` while the work runs in the background, then reports the result.
 
 All settings (WiFi credentials, TCP host/port, node name, TCP enabled state, volume, keyboard backlight, auto-announce, sleep timeout) are saved to `/rns/settings.json` and restored on boot. If WiFi and TCP were enabled when the device was last used, they reconnect automatically on startup.
 
 ### Screen Power-Off
 
-The screen turns off automatically after a configurable inactivity timeout (10 s default; set to 30 s / 60 s / never under Settings → Sleep) to save battery, and never sleeps while a page transfer or audio playback is in progress. Any keypress, trackball event, incoming message, or peer announce wakes the screen. The first input after wake is consumed (not processed) to prevent accidental actions. The MCU stays awake to receive LoRa packets — only the backlight is toggled. All SPI display writes are skipped while the screen is off, freeing the bus for LoRa.
+The screen turns off automatically after a configurable inactivity timeout (10 s default; set to 30 s / 60 s / never under Settings → Sleep) to save battery, and never sleeps while a page transfer or audio playback is in progress. Any keypress or trackball event wakes the screen; whether an incoming message or peer announce also wakes it follows the Settings → Wake policy (messages only by default). The first input after wake is consumed (not processed) to prevent accidental actions. The MCU stays awake to receive LoRa packets — only the backlight is toggled. All SPI display writes are skipped while the screen is off, freeing the bus for LoRa.
 
 ### Screen Lock
 

--- a/nomad_browser.py
+++ b/nomad_browser.py
@@ -91,7 +91,8 @@ def _on_announce(dest_hash, app_data, packet):
         return
     _gui.add_nomad_node(dest_hash, _decode_name(app_data),
                         hops=_node_hops(dest_hash))
-    _gui.wake_screen()
+    if _gui._wake_mode == 1:  # announces wake only under Wake: all
+        _gui.wake_screen()
 
 
 

--- a/rnsh_client.py
+++ b/rnsh_client.py
@@ -94,7 +94,8 @@ def _on_announce(dest_hash, app_data, packet):
         return
     if _gui is not None:
         _gui.add_shell_node(dest_hash, hops=_node_hops(dest_hash))
-        _gui.wake_screen()
+        if _gui._wake_mode == 1:  # announces wake only under Wake: all
+            _gui.wake_screen()
 
 
 

--- a/tdeck_node.py
+++ b/tdeck_node.py
@@ -493,8 +493,9 @@ def _on_message_inner(message):
             gui.snr = iface.snr
             break
 
-    # Wake screen and play notification
-    gui.wake_screen()
+    # Wake screen and play notification (mode 2 = never wake automatically)
+    if gui._wake_mode != 2:
+        gui.wake_screen()
     if DEBUG >= 1:
         print("[RX] wake ok")
     sound.play_rx()
@@ -556,7 +557,8 @@ def on_announce(destination_hash, display_name):
         pass
 
     gui.add_peer(destination_hash, display_name, rssi=rssi, hops=hops, via=via)
-    gui.wake_screen()
+    if gui._wake_mode == 1:  # only mode 1 wakes on announces; a live mesh never sleeps otherwise
+        gui.wake_screen()
     if DEBUG >= 1:
         print("[Peer]", display_name or "?", "[" + destination_hash.hex()[:8] + "]",
               "hops:", hops)
@@ -1225,6 +1227,13 @@ def set_screen_timeout(ms):
     _save_settings(settings)
 
 
+def set_wake_mode(mode):
+    """GUI: persist the auto-wake policy (0 = messages, 1 = all, 2 = never)."""
+    settings = _load_settings()
+    settings["wake_mode"] = int(mode)
+    _save_settings(settings)
+
+
 def forget_peer(key):
     """GUI: a peer was deleted — drop its LXMF-hash mappings too so a fresh
     announce re-adds it cleanly."""
@@ -1256,6 +1265,7 @@ gui.on_kbd_backlight = set_kbd_backlight
 gui.on_ping = on_ping
 gui.on_auto_announce = set_auto_announce
 gui.on_screen_timeout = set_screen_timeout
+gui.on_wake_mode = set_wake_mode
 gui.on_delete_peer = forget_peer
 gui.get_radio_stats = get_radio_stats
 gui.my_address = dest.hexhash
@@ -1600,6 +1610,9 @@ def _auto_connect_wifi():
     _st = settings.get("screen_timeout_ms")
     if _st is not None:
         gui._screen_timeout_ms = int(_st)
+    _wm = settings.get("wake_mode")
+    if _wm is not None:
+        gui._wake_mode = int(_wm)
     # WiFi reconnect is deferred to the event loop (_auto_connect_wifi_async) so a
     # slow or absent AP can never block boot on the loading screen.
 

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -25,6 +25,7 @@ class _Pin:
     OUT = 1
     PULL_UP = 2
     IRQ_FALLING = 4
+    IRQ_RISING = 8
 
     def __init__(self, *a, **k):
         pass

--- a/tests/test_shell_font.py
+++ b/tests/test_shell_font.py
@@ -24,7 +24,7 @@ sys.modules.setdefault("uasyncio", types.ModuleType("uasyncio"))
 
 
 class _Pin:
-    IN = OUT = PULL_UP = IRQ_FALLING = 0
+    IN = OUT = PULL_UP = IRQ_FALLING = IRQ_RISING = 0
 
     def __init__(self, *a, **k):
         pass

--- a/tests/test_ui_browser.py
+++ b/tests/test_ui_browser.py
@@ -372,10 +372,18 @@ def test_settings_timeout_and_volume_adjust():
     g._volume = 10
     g._settings_adjust(1)
     assert g._volume == 10                       # clamped
+    g._settings_idx = 8                          # Wake policy
+    saved_w = []
+    g.on_wake_mode = lambda m: saved_w.append(m)
+    g._wake_mode = 0
+    g._settings_adjust(1)
+    assert g._wake_mode == 1 and saved_w[-1] == 1
+    g._settings_adjust(-1)
+    assert g._wake_mode == 0                     # wraps both ways
     g._settings_idx = 0
     for _ in range(20):
         g._settings_scroll_down()
-    assert g._settings_idx == 10                  # 11 items now (LoRa cfg added)
+    assert g._settings_idx == 11                  # 12 items now (Wake added)
 
 
 def test_browser_prev_next_and_paging():

--- a/tests/test_ui_browser.py
+++ b/tests/test_ui_browser.py
@@ -23,6 +23,7 @@ class _Pin:
     OUT = 1
     PULL_UP = 2
     IRQ_FALLING = 4
+    IRQ_RISING = 8
 
     def __init__(self, *a, **k):
         pass

--- a/tests/test_ui_lora_cfg.py
+++ b/tests/test_ui_lora_cfg.py
@@ -20,6 +20,7 @@ class _Pin:
     OUT = 1
     PULL_UP = 2
     IRQ_FALLING = 4
+    IRQ_RISING = 8
 
     def __init__(self, *a, **k):
         pass

--- a/tests/test_ui_lora_cfg.py
+++ b/tests/test_ui_lora_cfg.py
@@ -67,7 +67,7 @@ def _open_lora(cfg=None):
     g.set_lora_config(cfg or _DEFAULT)
     g.state = ui.STATE_SETTINGS
     g._settings_page = ui._SET_MAIN
-    g._settings_idx = 9  # LoRa cfg row (inserted before the inert Addr row)
+    g._settings_idx = 10  # LoRa cfg row (inserted before the inert Addr row)
     g.handle_key(b"\x0d")
     return g
 

--- a/tests/test_ui_shell.py
+++ b/tests/test_ui_shell.py
@@ -20,6 +20,7 @@ class _Pin:
     OUT = 1
     PULL_UP = 2
     IRQ_FALLING = 4
+    IRQ_RISING = 8
 
     def __init__(self, *a, **k):
         pass
@@ -301,6 +302,84 @@ def test_exit_then_any_key_leaves():
     assert g._shell_status and "exited" in g._shell_status
     g.handle_key(b"x")
     assert g.state == ui.STATE_NODES
+
+
+class _ClickPin:
+    def __init__(self):
+        self.v = 1
+
+    def value(self):
+        return self.v
+
+
+def test_click_isr_classifies_short_and_long():
+    g = _mkui()
+    p = _ClickPin()
+    clock = [10000]
+    real = _time.ticks_ms
+    _time.ticks_ms = lambda: clock[0]
+    try:
+        p.v = 0; g._irq_handler_click(p)          # press
+        clock[0] += 100
+        p.v = 1; g._irq_handler_click(p)          # released well under 700ms
+        assert (g._irq_click, g._irq_long_click) == (1, 0)
+        clock[0] += 500
+        p.v = 0; g._irq_handler_click(p)
+        clock[0] += 800
+        p.v = 1; g._irq_handler_click(p)          # held past the threshold
+        assert (g._irq_click, g._irq_long_click) == (1, 1)
+        p.v = 1; g._irq_handler_click(p)          # stray release: ignored
+        assert (g._irq_click, g._irq_long_click) == (1, 1)
+    finally:
+        _time.ticks_ms = real
+
+
+def test_long_click_locks_and_a_single_click_unlocks():
+    g = _mkui()
+    g._irq_long_click = 1; g.handle_trackball()
+    assert g.locked and not g._screen_on
+
+    # Locked: rolls and external wakes are still discarded
+    g._irq_right = 1; g.handle_trackball()
+    assert g.node_tab == ui.TAB_MSG and not g._screen_on
+    g.wake_screen()
+    assert not g._screen_on
+
+    # One click is enough to get back in — no hold required
+    g._irq_click = 1; g.handle_trackball()
+    assert not g.locked and g._screen_on and g.dirty
+
+
+def test_a_long_click_still_unlocks():
+    # The gesture that locked it keeps working as a way back in, so a user
+    # who holds out of habit is not stuck.
+    g = _mkui()
+    g._irq_long_click = 1; g.handle_trackball()
+    g._irq_long_click = 1; g.handle_trackball()
+    assert not g.locked and g._screen_on
+
+
+def test_the_unlocking_click_is_swallowed():
+    # The click that unlocks must not also act on whatever the cursor was
+    # sitting on, and anything drained alongside it goes too.
+    g = _mkui()
+    g._irq_long_click = 1; g.handle_trackball()
+    g._irq_click = 1; g._irq_right = 1; g.handle_trackball()
+    assert not g.locked
+    assert g.node_tab == ui.TAB_MSG
+
+
+def test_a_click_alone_never_locks():
+    g = _mkui()
+    g._irq_click = 1; g.handle_trackball()
+    assert not g.locked
+
+
+def test_lock_refused_while_recording():
+    g = _mkui()
+    g.state = ui.STATE_RECORDING
+    g._irq_long_click = 1; g.handle_trackball()
+    assert not g.locked and g._screen_on
 
 
 if __name__ == "__main__":

--- a/ui.py
+++ b/ui.py
@@ -470,6 +470,7 @@ class UI:
         self._wifi_err = ""            # last connect failure note (shown on scan page)
         self._tcp_connecting = False   # True while an async TCP connect is running
         self._screen_timeout_ms = _SCREEN_TIMEOUT_MS  # configurable inactivity sleep
+        self._wake_mode = 0  # 0 = messages only, 1 = messages + announces, 2 = never
 
         # LoRa radio config editor (Settings > LoRa cfg). _lora_cfg mirrors the
         # live interface params (pushed in by tdeck_node.py via set_lora_config);
@@ -535,6 +536,7 @@ class UI:
         self.on_browser_exit = None   # () -> None — left the browser (free the link)
         self.on_net_seed = None       # () -> None — populate nomad_nodes from storage
         self.on_screen_timeout = None # (ms) -> None — persist inactivity timeout
+        self.on_wake_mode = None      # (mode) -> None — persist auto-wake policy
         self.on_auto_announce = None  # (enabled) -> None — start/stop periodic announce
         self.on_delete_peer = None    # (dest_hash_bytes) -> None — forget a peer/node
         # rnsh shell callbacks (wired by tdeck_node.py)
@@ -2262,13 +2264,18 @@ class UI:
                     self._cache = [''] * 15
                     self.dirty = True
                     return True
-                elif self._settings_idx == 8:  # Radio stats page
+                elif self._settings_idx == 8:  # Auto-wake policy cycle
+                    self._cycle_wake(1)
+                    self._cache = [''] * 15
+                    self.dirty = True
+                    return True
+                elif self._settings_idx == 9:  # Radio stats page
                     self._settings_page = _SET_RADIO
                     self._settings_scroll = 0
                     self._cache = [''] * 15
                     self.dirty = True
                     return True
-                elif self._settings_idx == 9:  # LoRa radio config page
+                elif self._settings_idx == 10:  # LoRa radio config page
                     self._settings_page = _SET_LORA
                     self._lora_edit = dict(self._lora_cfg)
                     self._lora_field = 0
@@ -2276,11 +2283,11 @@ class UI:
                     self._cache = [''] * 15
                     self.dirty = True
                     return True
-                # idx 10 (address) is informational — Enter does nothing
+                # idx 11 (address) is informational — Enter does nothing
         elif self._settings_page == _SET_RADIO:
             if ch == 0x1B or ch == 0x08:
                 self._settings_page = _SET_MAIN
-                self._settings_idx = 8
+                self._settings_idx = 9
                 self._cache = [''] * 15
                 self.dirty = True
                 return True
@@ -2289,7 +2296,7 @@ class UI:
                 self._lora_edit = None
                 self._lora_applying = ""
                 self._settings_page = _SET_MAIN
-                self._settings_idx = 9
+                self._settings_idx = 10
                 self._cache = [''] * 15
                 self.dirty = True
                 return True
@@ -2507,6 +2514,9 @@ class UI:
         ms = self._screen_timeout_ms
         return "never" if not ms else str(ms // 1000) + "s"
 
+    def _wake_label(self):
+        return ("msgs", "all", "never")[self._wake_mode]
+
     def _draw_settings_main(self):
         self._draw_row_cached(1, "Settings", BODY_Y, self.NEON_CYAN)
 
@@ -2526,14 +2536,15 @@ class UI:
         kbbl_line = "KbBL: " + ("ON" if self._kbd_bl else "OFF")
         anc_line = "Announce: " + ("AUTO" if self._auto_announce else "manual")
         sleep_line = "Sleep: " + self._timeout_label()
+        wake_line = "Wake: " + self._wake_label()
         radio_line = "Radio stats"
         c = self._lora_cfg
         loracfg_line = ("LoRa cfg: %dk SF%d BW%s"
                         % (c["freq_khz"], c["sf"], c["bw"]))
         addr_line = "Addr: " + (self.my_address or "?")
         items = [wifi_line, tcp_line, name_line, lora_line, vol_line,
-                 kbbl_line, anc_line, sleep_line, radio_line, loracfg_line,
-                 addr_line]
+                 kbbl_line, anc_line, sleep_line, wake_line, radio_line,
+                 loracfg_line, addr_line]
         for i in range(BODY_ROWS - 1):
             y = BODY_Y + (i + 1) * CHAR_H
             if i < len(items):
@@ -3047,9 +3058,9 @@ class UI:
 
     def _settings_scroll_down(self):
         if self._settings_page == _SET_MAIN:
-            # 11 items: WiFi TCP Name LoRa Vol KbBL Announce Sleep Radio
+            # 12 items: WiFi TCP Name LoRa Vol KbBL Announce Sleep Wake Radio
             #           LoRaCfg Addr
-            if self._settings_idx < 10:
+            if self._settings_idx < 11:
                 self._settings_idx += 1
         elif self._settings_page == _SET_WIFI_SCAN:
             if self._settings_idx < len(self._wifi_networks) - 1:
@@ -3076,6 +3087,15 @@ class UI:
         if self.on_screen_timeout:
             try:
                 self.on_screen_timeout(self._screen_timeout_ms)
+            except Exception:
+                pass
+
+    def _cycle_wake(self, delta=1):
+        """Step the auto-wake policy: 0 = messages, 1 = everything, 2 = never."""
+        self._wake_mode = (self._wake_mode + delta) % 3
+        if self.on_wake_mode:
+            try:
+                self.on_wake_mode(self._wake_mode)
             except Exception:
                 pass
 
@@ -3148,6 +3168,8 @@ class UI:
                 self.on_volume(self._volume)
         elif self._settings_idx == 7:    # Sleep timeout
             self._cycle_timeout(delta)
+        elif self._settings_idx == 8:    # Auto-wake policy
+            self._cycle_wake(delta)
         else:
             return
         self._cache = [''] * 15

--- a/ui.py
+++ b/ui.py
@@ -108,6 +108,8 @@ MAX_CACHED_IMAGES = 3  # max JPEG payloads kept in RAM
 # Horizontal stays high: tab switches should be deliberate.
 _TB_DEBOUNCE_MS = 30
 _TB_H_DEBOUNCE_MS = 150
+# Trackball click held at least this long toggles the device lock
+_TB_LONG_PRESS_MS = 700
 
 # Screen power-off timeout options (ms); 0 = never sleep
 _SCREEN_TIMEOUT_MS = 10000
@@ -422,17 +424,22 @@ class UI:
         self._irq_up = 0
         self._irq_down = 0
         self._irq_click = 0
+        self._irq_long_click = 0
         self._irq_left = 0
         self._irq_right = 0
         # ISR debounce timestamps (ticks_ms is ISR-safe)
         self._irq_last_scroll = 0
         self._irq_last_click = 0
         self._irq_last_h = 0
+        self._irq_press_ms = 0  # falling edge of the click currently held
+        self._irq_pressed = 0   # 1 between a press and its release
 
-        # Register hardware interrupts on trackball pins
+        # Register hardware interrupts on trackball pins. The click pin needs
+        # both edges: press starts the timer, release decides short vs. long.
         self._tb_up.irq(trigger=Pin.IRQ_FALLING, handler=self._irq_handler_up)
         self._tb_down.irq(trigger=Pin.IRQ_FALLING, handler=self._irq_handler_down)
-        self._tb_click.irq(trigger=Pin.IRQ_FALLING, handler=self._irq_handler_click)
+        self._tb_click.irq(trigger=Pin.IRQ_FALLING | Pin.IRQ_RISING,
+                           handler=self._irq_handler_click)
         self._tb_left.irq(trigger=Pin.IRQ_FALLING, handler=self._irq_handler_left)
         self._tb_right.irq(trigger=Pin.IRQ_FALLING, handler=self._irq_handler_right)
 
@@ -498,6 +505,7 @@ class UI:
         self._last_activity = time.ticks_ms()
         self._screen_on = True
         self._bl = None  # backlight pin, set by set_backlight()
+        self.locked = False  # long-press lock: screen off, all input dropped
 
         # Node identity/info (set by tdeck_node.py)
         self.my_address = None       # own LXMF address hex string
@@ -541,7 +549,11 @@ class UI:
     def set_backlight(self, bl_pin):
         self._bl = bl_pin
 
-    def wake_screen(self):
+    def wake_screen(self, force=False):
+        # One guard for every wake source — including the message/announce
+        # wakes tdeck_node.py fires from the RX path. Only unlocking forces.
+        if self.locked and not force:
+            return
         if not self._screen_on:
             if self._bl:
                 self._bl.value(1)
@@ -555,6 +567,18 @@ class UI:
             if self._bl:
                 self._bl.value(0)
             self._screen_on = False
+
+    def lock(self):
+        """Blank the screen and ignore input until the next trackball click.
+        Sounds, unread counters and the radio keep running."""
+        self.locked = True
+        self.sleep_screen()
+
+    def unlock(self):
+        self.locked = False
+        self.wake_screen(force=True)
+        self._cache = [''] * 15  # row caches are stale after the screen blanked
+        self.dirty = True
 
     # --- Drawing helpers ---
 
@@ -2764,10 +2788,23 @@ class UI:
             self._irq_down += 1
 
     def _irq_handler_click(self, pin):
+        # Fires on both edges. Hard-IRQ context: int arithmetic and attribute
+        # stores only — anything that allocates raises inside the ISR.
         t = time.ticks_ms()
-        if time.ticks_diff(t, self._irq_last_click) >= 200:
-            self._irq_last_click = t
-            self._irq_click += 1
+        if pin.value():  # rising edge: button released, classify the press
+            # A release we never saw the press of (button held across boot)
+            # carries no valid hold time — drop it rather than read it as long.
+            if self._irq_pressed:
+                self._irq_pressed = 0
+                if time.ticks_diff(t, self._irq_press_ms) >= _TB_LONG_PRESS_MS:
+                    self._irq_last_click = t  # release bounce adds no click
+                    self._irq_long_click += 1
+                elif time.ticks_diff(t, self._irq_last_click) >= 200:
+                    self._irq_last_click = t
+                    self._irq_click += 1
+        else:            # falling edge: button pressed, start the hold timer
+            self._irq_press_ms = t
+            self._irq_pressed = 1
 
     def _irq_handler_left(self, pin):
         t = time.ticks_ms()
@@ -2785,11 +2822,30 @@ class UI:
         """Drain IRQ-captured trackball events."""
         # Read and reset counters — no disable_irq needed; worst case
         # an ISR fires between read and reset, losing one tick (harmless).
+        long_click = self._irq_long_click;  self._irq_long_click = 0
         up = self._irq_up;  self._irq_up = 0
         down = self._irq_down;  self._irq_down = 0
         click = self._irq_click;  self._irq_click = 0
         left = self._irq_left;  self._irq_left = 0
         right = self._irq_right;  self._irq_right = 0
+
+        # Locking takes a long click; getting back in takes any click. The
+        # ball sits recessed and stiff enough that a pocket press is not a
+        # real risk, and demanding a 0.7s hold to look at the screen reads as
+        # a stuck device. Either way the event is swallowed, so the click
+        # that unlocks cannot also act on whatever it landed on.
+        if self.locked:
+            if click or long_click:
+                self.unlock()
+                return True
+            return False
+
+        # Locking is refused while recording: the mic thread owns the CPU and
+        # no display state may change until capture ends.
+        if long_click:
+            if self.state != STATE_RECORDING:
+                self.lock()
+            return True
 
         if not (up or down or click or left or right):
             return False
@@ -3388,6 +3444,8 @@ class UI:
                 key = self.get_key()
                 if key == b'\x00':
                     break
+                if self.locked:
+                    continue  # keep draining the I2C queue, drop the keys
                 if not self._screen_on:
                     self.wake_screen()
                     # Drain remaining keys — first press only wakes


### PR DESCRIPTION
On a live mesh every announce calls wake_screen(), so the display never reaches its inactivity timeout or constantly wakes again.
This adds a "Wake:" row to Settings that gates the automatic "wakes:" messages only (the new default), everything (the old behaviour), or never.

Based on the screen-lock PR (#3) - only the top two commits are new here; they share the wake/lock path in ui.py.