### PR TITLE
Call the shell tab RNSH, not SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Text displays in English as well as Bulgarian, Russian, Ukrainian and Belarusian
 
 <p>
 <img src="images/splash.jpeg" width="49%" alt="Splash screen"/>
-<img src="images/lxmf-list.jpeg" width="49%" alt="Messenger — LXMF peer list with MSG / NET / SSH tabs"/>
+<img src="images/lxmf-list.jpeg" width="49%" alt="Messenger — LXMF peer list with MSG / NET / RNSH tabs"/>
 </p>
 <p>
 <img src="images/nomadnet-reader.jpeg" width="49%" alt="NomadNet browser rendering a node page with block-glyph banner art"/>
@@ -229,14 +229,14 @@ mpremote cp tdeck_node.py :/main.py
 
 ### Node List Screen
 
-The device starts on the node list screen with three tabs: **MSG** (LXMF chat peers), **NET** (browsable NomadNet nodes), and **SSH** (rnsh shell listeners), all populated from announces. Peers with unread messages are marked with `*`. A NomadNet instance announces both aspects, so it appears in both MSG and NET — chattable in MSG, browsable in NET.
+The device starts on the node list screen with three tabs: **MSG** (LXMF chat peers), **NET** (browsable NomadNet nodes), and **RNSH** (rnsh shell listeners), all populated from announces. Peers with unread messages are marked with `*`. A NomadNet instance announces both aspects, so it appears in both MSG and NET — chattable in MSG, browsable in NET.
 
 | Action | Input |
 |---|---|
-| Switch MSG/NET/SSH tab | Trackball left/right (or `b`) |
+| Switch MSG/NET/RNSH tab | Trackball left/right (or `b`) |
 | Select peer/node | Trackball up/down |
 | Open chat / node page / shell | Trackball click (or Enter) |
-| Enter rnsh hash manually (SSH) | Press `m` |
+| Enter rnsh hash manually (RNSH) | Press `m` |
 | Send announce | Press `a` |
 | Open settings | Press `s` |
 | Ping selected peer (MSG) | Press `p` |
@@ -273,9 +273,9 @@ re-fetching over LoRa.
 
 v1 limitations: read-only (form fields render as placeholders), pages are capped at 16 KB, and nodes that require identification will time out.
 
-### rnsh Shell (SSH tab)
+### rnsh Shell (RNSH tab)
 
-The SSH tab lists [rnsh](https://github.com/acehoss/rnsh) listeners heard via announces; press `m` to type a listener's 32-hex destination hash directly. Clicking one establishes an encrypted link, identifies your node, exchanges protocol versions, and starts the remote default shell on a pty. Output renders as a **scrolling text log** on a **53×16 grid** (see the font note below) — line-oriented commands (`ls -l`, `ps`, `git log`, `cat`) keep their column layout instead of wrapping; full-screen TUIs (`vim`, `htop`) won't render correctly (ANSI cursor addressing is stripped in this MVP). The listener must authorize your **identity hash** (shown at boot and on the SSH manual-entry screen) via its `-a` flag or `~/.config/rnsh/allowed_identities`, unless it runs `--no-auth`.
+The RNSH tab lists [rnsh](https://github.com/acehoss/rnsh) listeners heard via announces; press `m` to type a listener's 32-hex destination hash directly. Clicking one establishes an encrypted link, identifies your node, exchanges protocol versions, and starts the remote default shell on a pty. Output renders as a **scrolling text log** on a **53×16 grid** (see the font note below) — line-oriented commands (`ls -l`, `ps`, `git log`, `cat`) keep their column layout instead of wrapping; full-screen TUIs (`vim`, `htop`) won't render correctly (ANSI cursor addressing is stripped in this MVP). The listener must authorize your **identity hash** (shown at boot and on the RNSH manual-entry screen) via its `-a` flag or `~/.config/rnsh/allowed_identities`, unless it runs `--no-auth`.
 
 | Action | Input |
 |---|---|

--- a/tests/test_ui_shell.py
+++ b/tests/test_ui_shell.py
@@ -93,8 +93,8 @@ def test_ssh_tab_lists_nodes():
     assert g.node_tab == ui.TAB_SSH
     g.add_shell_node(b"\xa3" * 16, hops=2)
     g.draw()
-    # SSH(1) in the tab bar; the hash prefix shows as the row name
-    assert any("SSH(1)" in str(c[1]) for c in g.tft.calls if c[0] == "text")
+    # RNSH(1) in the tab bar; the hash prefix shows as the row name
+    assert any("RNSH(1)" in str(c[1]) for c in g.tft.calls if c[0] == "text")
     assert g._shell_keys == [b"\xa3" * 16]
 
 

--- a/ui.py
+++ b/ui.py
@@ -747,7 +747,7 @@ class UI:
         tabs = (
             " MSG(" + str(len(self._peer_keys)) + ("*" if un else "") + ") ",
             " NET(" + str(len(self._node_keys)) + ") ",
-            " SSH(" + str(len(self._shell_keys)) + ") ",
+            " RNSH(" + str(len(self._shell_keys)) + ") ",
         )
         cache_key = str(self.node_tab) + "".join(tabs)
         if self._cache[1] == cache_key:


### PR DESCRIPTION
Nitpick: The protocol is rnsh over a Reticulum link; nothing about it is SSH. Visible strings only - the TAB_SSH/ssh_* internals keep their names for now.